### PR TITLE
Fix listing blogs for bookmarklet

### DIFF
--- a/plugins/QuickRebuild/tmpl/mt-rebuild.js
+++ b/plugins/QuickRebuild/tmpl/mt-rebuild.js
@@ -712,7 +712,7 @@ ToIMT.prototype.list_blogs = function(sites, onListed) {
                 }));
             });
 
-            if (parseInt(data.result.page, 10) !== parseInt(data.result.page_max, 10)) {
+            if (parseInt(data.result.page_max, 10) > 0 && parseInt(data.result.page, 10) !== parseInt(data.result.page_max, 10)) {
                 inner(parseInt(data.result.page, 10) + 1);
             }
             else {

--- a/plugins/QuickRebuild/tmpl/mt-rebuild.js
+++ b/plugins/QuickRebuild/tmpl/mt-rebuild.js
@@ -694,7 +694,7 @@ ToIMT.prototype.list_blogs = function(sites, onListed) {
             data: {
                 __mode: "filtered_list",
                 datasource: "blog",
-                blog_id: sites[site_index].id,
+                blog_id: sites[site_index].get('id'),
                 columns: "name",
                 limit: "50",
                 page: offset,


### PR DESCRIPTION
日本語で失礼します。

bookmarklet 版で、2点不具合が見つかったので報告します。
1点目は、子ブログが存在しないウェブサイトが存在する場合に `list_blogs` メソッドが無限ループしてしまうという点、2点目は、ブログのリストアップにて、無関係のウェブサイト以下にブログが挿入されてしまう点です。

いずれも bookmarklet 版でしか再現しません。
